### PR TITLE
fix release version without job limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ debug: debug/CMakeLists.txt
 	make -C debug -j$(NUMPROC)
 
 release: release/CMakeLists.txt
-	make -C release -j
+	make -C release -j$(NUMPROC)
 
 test: debug
 	CTEST_OUTPUT_ON_FAILURE=1 make -C debug test


### PR DESCRIPTION
release without number of cores will exhausted the OS.