### PR TITLE
Fix for segfault in path::pop_back

### DIFF
--- a/src/common/model/path.h
+++ b/src/common/model/path.h
@@ -128,7 +128,13 @@ public:
         }
     }
 
-    void pop_back() { path_.pop_back(); }
+    void pop_back()
+    {
+        if (!path_.empty())
+        {
+            path_.pop_back();
+        }
+    }
 
     std::optional<path> parent() const
     {


### PR DESCRIPTION
I ran into a segfault in path::pop_back, stack trace added for reference.

```
Thread 1 (Thread 0x7fdea1a5a700 (LWP 620634)):
#0  raise (sig=<optimized out>) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00005607a45f4c05 in backward::SignalHandling::sig_handler (signo=11, info=0x7fdea1a56c30, _ctx=0x7fdea1a56b00) at /home/bramv/src/projects/clang-uml/thirdparty/backward-cpp/backward.hpp:4298
#2  <signal handler called>
#3  0x00007fdea51205c4 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string() () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00005607a466f074 in __gnu_cxx::new_allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::destroy<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > (this=0x7fdea1a57220, __p=0xffffffffffffffe0) at /usr/include/c++/9/ext/new_allocator.h:152
#5  0x00005607a464d769 in std::allocator_traits<std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::destroy<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > (__a=..., __p=0xffffffffffffffe0) at /usr/include/c++/9/bits/alloc_traits.h:496
#6  0x00005607a462ba35 in std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::pop_back (this=0x7fdea1a57220) at /usr/include/c++/9/bits/stl_vector.h:1226
#7  0x00005607a49984f0 in clanguml::common::model::path<clanguml::common::model::ns_path_separator>::pop_back (this=0x7fdea1a57220) at /home/bramv/src/projects/clang-uml/src/common/model/path.h:131
#8  0x00005607a49add3e in clanguml::common::get_qualified_name<clang::CXXRecordDecl> (declaration=...) at /home/bramv/src/projects/clang-uml/src/common/clang_utils.h:61
#9  0x00005607a49abdc7 in clanguml::common::to_id<clang::CXXRecordDecl> (declaration=...) at /home/bramv/src/projects/clang-uml/src/common/clang_utils.cc:277
#10 0x00005607a4987f1c in clanguml::class_diagram::visitor::translation_unit_visitor::find_relationships (this=0x7fde9f374ae0, type=..., relationships=std::vector of length 0, capacity 0, relationship_hint=clanguml::common::model::relationship_t::kAggregation) at /home/bramv/src/projects/clang-uml/src/class_diagram/visitor/translation_unit_visitor.cc:979
#11 0x00005607a4987bcc in clanguml::class_diagram::visitor::translation_unit_visitor::find_relationships (this=0x7fde9f374ae0, type=..., relationships=std::vector of length 0, capacity 0, relationship_hint=clanguml::common::model::relationship_t::kAggregation) at /home/bramv/src/projects/clang-uml/src/class_diagram/visitor/translation_unit_visitor.cc:904
#12 0x00005607a49881a8 in clanguml::class_diagram::visitor::translation_unit_visitor::process_function_parameter (this=0x7fde9f374ae0, p=..., method=..., c=..., template_parameter_names=Python Exception <class 'AttributeError'> 'NoneType' object has no attribute 'pointer': 
std::set with 0 elements) at /home/bramv/src/projects/clang-uml/src/class_diagram/visitor/translation_unit_visitor.cc:1015
#13 0x00005607a498709c in clanguml::class_diagram::visitor::translation_unit_visitor::process_method (this=0x7fde9f374ae0, mf=..., c=...) at /home/bramv/src/projects/clang-uml/src/class_diagram/visitor/translation_unit_visitor.cc:849
#14 0x00005607a4986331 in clanguml::class_diagram::visitor::translation_unit_visitor::process_class_children (this=0x7fde9f374ae0, cls=0x7fde95d48f88, c=...) at /home/bramv/src/projects/clang-uml/src/class_diagram/visitor/translation_unit_visitor.cc:739
#15 0x00005607a4983d93 in clanguml::class_diagram::visitor::translation_unit_visitor::process_class_declaration (this=0x7fde9f374ae0, cls=..., c=...) at /home/bramv/src/projects/clang-uml/src/class_diagram/visitor/translation_unit_visitor.cc:507
#16 0x00005607a49822a0 in clanguml::class_diagram::visitor::translation_unit_visitor::VisitCXXRecordDecl (this=0x7fde9f374ae0, cls=0x7fde95d48f88) at /home/bramv/src/projects/clang-uml/src/class_diagram/visitor/translation_unit_visitor.cc:377
#17 0x00005607a47280c0 in clang::RecursiveASTVisitor<clanguml::class_diagram::visitor::translation_unit_visitor>::WalkUpFromCXXRecordDecl (this=0x7fde9f374ae0, D=0x7fde95d48f88) at /usr/lib/llvm-12/include/clang/AST/DeclNodes.inc:263
#18 0x00005607a46fcafb in clang::RecursiveASTVisitor<clanguml::class_diagram::visitor::translation_unit_visitor>::TraverseCXXRecordDecl (this=0x7fde9f374ae0, D=0x7fde95d48f88) at /usr/lib/llvm-12/include/clang/AST/RecursiveASTVisitor.h:1879
#19 0x00005607a46d64a1 in clang::RecursiveASTVisitor<clanguml::class_diagram::visitor::translation_unit_visitor>::TraverseDecl (this=0x7fde9f374ae0, D=0x7fde95d48f88) at /usr/lib/llvm-12/include/clang/AST/DeclNodes.inc:263
#20 0x00005607a47215fa in clang::RecursiveASTVisitor<clanguml::class_diagram::visitor::translation_unit_visitor>::TraverseDeclContextHelper (this=0x7fde9f374ae0, DC=0x7fde95d47e08) at /usr/lib/llvm-12/include/clang/AST/RecursiveASTVisitor.h:1389
#21 0x00005607a46fcb6d in clang::RecursiveASTVisitor<clanguml::class_diagram::visitor::translation_unit_visitor>::TraverseCXXRecordDecl (this=0x7fde9f374ae0, D=0x7fde95d47dc8) at /usr/lib/llvm-12/include/clang/AST/RecursiveASTVisitor.h:1879
#22 0x00005607a46d64a1 in clang::RecursiveASTVisitor<clanguml::class_diagram::visitor::translation_unit_visitor>::TraverseDecl (this=0x7fde9f374ae0, D=0x7fde95d47dc8) at /usr/lib/llvm-12/include/clang/AST/DeclNodes.inc:263
#23 0x00005607a47215fa in clang::RecursiveASTVisitor<clanguml::class_diagram::visitor::translation_unit_visitor>::TraverseDeclContextHelper (this=0x7fde9f374ae0, DC=0x7fde95d47d88) at /usr/lib/llvm-12/include/clang/AST/RecursiveASTVisitor.h:1389
#24 0x00005607a46f9f60 in clang::RecursiveASTVisitor<clanguml::class_diagram::visitor::translation_unit_visitor>::TraverseNamespaceDecl (this=0x7fde9f374ae0, D=0x7fde95d47d58) at /usr/lib/llvm-12/include/clang/AST/RecursiveASTVisitor.h:1514
#25 0x00005607a46d60d8 in clang::RecursiveASTVisitor<clanguml::class_diagram::visitor::translation_unit_visitor>::TraverseDecl (this=0x7fde9f374ae0, D=0x7fde95d47d58) at /usr/lib/llvm-12/include/clang/AST/DeclNodes.inc:111
#26 0x00005607a47215fa in clang::RecursiveASTVisitor<clanguml::class_diagram::visitor::translation_unit_visitor>::TraverseDeclContextHelper (this=0x7fde9f374ae0, DC=0x7fde9c195200) at /usr/lib/llvm-12/include/clang/AST/RecursiveASTVisitor.h:1389
#27 0x00005607a4702ffa in clang::RecursiveASTVisitor<clanguml::class_diagram::visitor::translation_unit_visitor>::TraverseTranslationUnitDecl (this=0x7fde9f374ae0, D=0x7fde9c1951d8) at /usr/lib/llvm-12/include/clang/AST/RecursiveASTVisitor.h:1490
#28 0x00005607a46d6dfe in clang::RecursiveASTVisitor<clanguml::class_diagram::visitor::translation_unit_visitor>::TraverseDecl (this=0x7fde9f374ae0, D=0x7fde9c1951d8) at /usr/lib/llvm-12/include/clang/AST/DeclNodes.inc:601
#29 0x00005607a46d26b2 in clanguml::common::generators::plantuml::diagram_ast_consumer<clanguml::class_diagram::model::diagram, clanguml::config::class_diagram, clanguml::class_diagram::visitor::translation_unit_visitor>::HandleTranslationUnit (this=0x7fde9f374ad0, ast_context=...) at /home/bramv/src/projects/clang-uml/src/common/generators/plantuml/generator.h:382
#30 0x00007fdeab2d0d94 in clang::ParseAST(clang::Sema&, bool, bool) () from /usr/lib/llvm-12/lib/libclang-cpp.so.12
#31 0x00007fdeac866118 in clang::FrontendAction::Execute() () from /usr/lib/llvm-12/lib/libclang-cpp.so.12
#32 0x00007fdeac7f3dd1 in clang::CompilerInstance::ExecuteAction(clang::FrontendAction&) () from /usr/lib/llvm-12/lib/libclang-cpp.so.12
#33 0x00007fdeac9d78ed in clang::tooling::FrontendActionFactory::runInvocation(std::shared_ptr<clang::CompilerInvocation>, clang::FileManager*, std::shared_ptr<clang::PCHContainerOperations>, clang::DiagnosticConsumer*) () from /usr/lib/llvm-12/lib/libclang-cpp.so.12
#34 0x00007fdeac9d764a in clang::tooling::ToolInvocation::runInvocation(char const*, clang::driver::Compilation*, std::shared_ptr<clang::CompilerInvocation>, std::shared_ptr<clang::PCHContainerOperations>) () from /usr/lib/llvm-12/lib/libclang-cpp.so.12
#35 0x00007fdeac9d6a74 in clang::tooling::ToolInvocation::run() () from /usr/lib/llvm-12/lib/libclang-cpp.so.12
#36 0x00007fdeac9d8b28 in clang::tooling::ClangTool::run(clang::tooling::ToolAction*) () from /usr/lib/llvm-12/lib/libclang-cpp.so.12
#37 0x00005607a4631d0c in clanguml::common::generators::plantuml::generate<clanguml::class_diagram::model::diagram, clanguml::config::class_diagram, clanguml::class_diagram::visitor::translation_unit_visitor> (db=..., name="basics", config=..., translation_units=std::vector of length 15, capacity 15 = {...}) at /home/bramv/src/projects/clang-uml/src/common/generators/plantuml/generator.h:475
#38 0x00005607a45d1341 in generate_diagram (od="docs/diagrams", name="basics", diagram=std::shared_ptr<struct clanguml::config::diagram> (use count 2, weak count 0) = {...}, db=..., translation_units=std::vector of length 15, capacity 15 = {...}, verbose=true) at /home/bramv/src/projects/clang-uml/src/main.cc:315
#39 0x00005607a45d1c4c in <lambda()>::operator()(void) const (__closure=0x5607a640ca60) at /home/bramv/src/projects/clang-uml/src/main.cc:401
#40 0x00005607a45d6470 in std::_Function_handler<void(), generate_diagrams(const std::vector<std::__cxx11::basic_string<char> >&, clanguml::config::config&, const string&, const std::unique_ptr<clang::tooling::CompilationDatabase>&, int, unsigned int, const std::map<std::__cxx11::basic_string<char>, std::vector<std::__cxx11::basic_string<char> > >&)::<lambda()> >::_M_invoke(const std::_Any_data &) (__functor=...) at /usr/include/c++/9/bits/std_function.h:300
#41 0x00005607a461e926 in std::function<void ()>::operator()() const (this=0x5607a63ff2d8) at /usr/include/c++/9/bits/std_function.h:688
#42 0x00005607a4a9255f in std::__invoke_impl<void, std::function<void ()>&>(std::__invoke_other, std::function<void ()>&) (__f=...) at /usr/include/c++/9/bits/invoke.h:60
#43 0x00005607a4a92238 in std::__invoke<std::function<void ()>&>(std::function<void ()>&) (__fn=...) at /usr/include/c++/9/bits/invoke.h:95
#44 0x00005607a4a91f39 in std::__future_base::_Task_state<std::function<void ()>, std::allocator<int>, void ()>::_M_run()::{lambda()#1}::operator()() const (this=0x5607a63ff2b0) at /usr/include/c++/9/future:1421
#45 0x00005607a4a92a5c in std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<void>, std::__future_base::_Result_base::_Deleter>, std::__future_base::_Task_state<std::function<void ()>, std::allocator<int>, void ()>::_M_run()::{lambda()#1}, void>::operator()() const (this=0x7fdea1a59d10) at /usr/include/c++/9/future:1362
#46 0x00005607a4a92620 in std::_Function_handler<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> (), std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<void>, std::__future_base::_Result_base::_Deleter>, std::__future_base::_Task_state<std::function<void ()>, std::allocator<int>, void ()>::_M_run()::{lambda()#1}, void> >::_M_invoke(std::_Any_data const&) (__functor=...) at /usr/include/c++/9/bits/std_function.h:286
#47 0x00005607a4a8c166 in std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>::operator()() const (this=0x7fdea1a59d10) at /usr/include/c++/9/bits/std_function.h:688
#48 0x00005607a4a8b924 in std::__future_base::_State_baseV2::_M_do_set(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*) (this=0x5607a63ff2b0, __f=0x7fdea1a59d10, __did_set=0x7fdea1a59c6f) at /usr/include/c++/9/future:561
#49 0x00005607a4a8e0b2 in std::__invoke_impl<void, void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::__invoke_memfun_deref, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&) (__f=@0x7fdea1a59cb0: (void (std::__future_base::_State_baseV2::*)(class std::__future_base::_State_baseV2 * const, class std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter>()> *, bool *)) 0x5607a4a8b8ea <std::__future_base::_State_baseV2::_M_do_set(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*)>, __t=@0x7fdea1a59c80: 0x5607a63ff2b0) at /usr/include/c++/9/bits/invoke.h:73
#50 0x00005607a4a8ce69 in std::__invoke<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&) (__fn=@0x7fdea1a59cb0: (void (std::__future_base::_State_baseV2::*)(class std::__future_base::_State_baseV2 * const, class std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter>()> *, bool *)) 0x5607a4a8b8ea <std::__future_base::_State_baseV2::_M_do_set(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*)>) at /usr/include/c++/9/bits/invoke.h:95
#51 0x00005607a4a8bd16 in std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&)::{lambda()#1}::operator()() const (this=0x7fdea1a59c00) at /usr/include/c++/9/mutex:671
#52 0x00005607a4a8bd45 in std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&)::{lambda()#2}::operator()() const (this=0x0) at /usr/include/c++/9/mutex:676
#53 0x00005607a4a8bd5a in std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&)::{lambda()#2}::_FUN() () at /usr/include/c++/9/mutex:676
#54 0x00007fdea51d04df in __pthread_once_slow (once_control=0x5607a63ff2c8, init_routine=0x7fdea50b2c20 <__once_proxy>) at pthread_once.c:116
#55 0x00005607a4a8afb6 in __gthread_once (__once=0x5607a63ff2c8, __func=0x7fdea50b2c20 <__once_proxy>) at /usr/include/x86_64-linux-gnu/c++/9/bits/gthr-default.h:700
#56 0x00005607a4a8be04 in std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&) (__once=..., __f=@0x7fdea1a59cb0: (void (std::__future_base::_State_baseV2::*)(class std::__future_base::_State_baseV2 * const, class std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter>()> *, bool *)) 0x5607a4a8b8ea <std::__future_base::_State_baseV2::_M_do_set(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*)>) at /usr/include/c++/9/mutex:683
#57 0x00005607a4a8b4db in std::__future_base::_State_baseV2::_M_set_result(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>, bool) (this=0x5607a63ff2b0, __res=..., __ignore_failure=false) at /usr/include/c++/9/future:401
#58 0x00005607a4a91fab in std::__future_base::_Task_state<std::function<void ()>, std::allocator<int>, void ()>::_M_run() (this=0x5607a63ff2b0) at /usr/include/c++/9/future:1423
#59 0x00005607a4a8cb27 in std::packaged_task<void ()>::operator()() (this=0x7fdea1a59da0) at /usr/include/c++/9/future:1551
#60 0x00005607a4a8ac7e in clanguml::util::thread_pool_executor::worker (this=0x7ffd0b9187e0) at /home/bramv/src/projects/clang-uml/src/util/thread_pool_executor.cc:70
#61 0x00005607a4a92e8d in std::__invoke_impl<void, void (clanguml::util::thread_pool_executor::*)(), clanguml::util::thread_pool_executor*> (__f=@0x5607a64093b0: (void (clanguml::util::thread_pool_executor::*)(class clanguml::util::thread_pool_executor * const)) 0x5607a4a8ac2a <clanguml::util::thread_pool_executor::worker()>, __t=@0x5607a64093a8: 0x7ffd0b9187e0) at /usr/include/c++/9/bits/invoke.h:73
#62 0x00005607a4a9299b in std::__invoke<void (clanguml::util::thread_pool_executor::*)(), clanguml::util::thread_pool_executor*> (__fn=@0x5607a64093b0: (void (clanguml::util::thread_pool_executor::*)(class clanguml::util::thread_pool_executor * const)) 0x5607a4a8ac2a <clanguml::util::thread_pool_executor::worker()>) at /usr/include/c++/9/bits/invoke.h:95
#63 0x00005607a4a92521 in std::thread::_Invoker<std::tuple<void (clanguml::util::thread_pool_executor::*)(), clanguml::util::thread_pool_executor*> >::_M_invoke<0ul, 1ul> (this=0x5607a64093a8) at /usr/include/c++/9/thread:244
#64 0x00005607a4a92212 in std::thread::_Invoker<std::tuple<void (clanguml::util::thread_pool_executor::*)(), clanguml::util::thread_pool_executor*> >::operator() (this=0x5607a64093a8) at /usr/include/c++/9/thread:251
#65 0x00005607a4a91f12 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (clanguml::util::thread_pool_executor::*)(), clanguml::util::thread_pool_executor*> > >::_M_run (this=0x5607a64093a0) at /usr/include/c++/9/thread:195
#66 0x00007fdea50b3de4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#67 0x00007fdea51c7609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#68 0x00007fdea4d9e133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

```

After checking whether the path_ member is empty, this segfault was solved. Please verify if this fix is correct, or if there is a more fundamental problem (and possibly a different fix?) leading to this crash.