### PR TITLE
Added test_case related to anonymous namespace.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ if(MSVC)
 endif(MSVC)
 
 if(LINK_LLVM_SHARED)
-    set(LIBTOOLING_LIBS clang-cpp LLVM)
+    set(LIBTOOLING_LIBS clang-cpp12 LLVM)
 else(LINK_LLVM_SHARED)
     set(LIBTOOLING_LIBS
         clangLex

--- a/docs/test_cases.md
+++ b/docs/test_cases.md
@@ -49,6 +49,7 @@
  * [t00048](./test_cases/t00048.md) - Test case for unique entity id with multiple translation units
  * [t00049](./test_cases/t00049.md) - Test case configurable type aliases
  * [t00050](./test_cases/t00050.md) - Test case for generating notes from comments using jinja templates
+ * [t00051](./test_cases/t00051.md) - Test case for anonymous namespace within named namespace
 ## Sequence diagrams
  * [t20001](./test_cases/t20001.md) - Basic sequence diagram test case
  * [t20002](./test_cases/t20002.md) - Free function sequence diagram test case

--- a/tests/t00051/.clang-uml
+++ b/tests/t00051/.clang-uml
@@ -1,0 +1,17 @@
+compilation_database_dir: ..
+output_directory: puml
+diagrams:
+  t00051_class:
+    type: class
+    glob:
+      - ../../tests/t00051/t00051.cc
+    comment_parser: clang
+    include:
+      namespaces:
+        - clanguml
+        - clanguml::t00051
+      context:
+        - clanguml::A
+        - clanguml::t00051::B
+        - clanguml::t00051::::C
+    using_namespace: clanguml

--- a/tests/t00051/t00051.cc
+++ b/tests/t00051/t00051.cc
@@ -1,0 +1,18 @@
+namespace clanguml {
+
+class A {
+};
+
+namespace t00051 {
+
+class B {
+};
+
+namespace {
+
+class C {
+};
+
+} // namespace
+} // namespace t00050
+} // namespace clanguml

--- a/tests/t00051/test_case.h
+++ b/tests/t00051/test_case.h
@@ -1,0 +1,44 @@
+/**
+ * tests/t00051/test_case.h
+ *
+ * Copyright (c) 2021-2023 Bartek Kryza <bkryza@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+TEST_CASE("t00051", "[test-case][class]")
+{
+    auto [config, db] = load_config("t00051");
+
+    auto diagram = config.diagrams["t00051_class"];
+
+    REQUIRE(diagram->name == "t00051_class");
+
+    auto model = generate_class_diagram(*db, diagram);
+
+    REQUIRE(model->name() == "t00051_class");
+
+    auto puml = generate_class_puml(diagram, *model);
+    AliasMatcher _A(puml);
+
+    // REQUIRE_THAT(puml, StartsWith("@startuml"));
+    // REQUIRE_THAT(puml, EndsWith("@enduml\n"));
+
+    // // Check if all classes exist
+    // REQUIRE_THAT(puml, IsClass(_A("A")));
+    // REQUIRE_THAT(puml, IsClass(_A("B")));
+    // REQUIRE_THAT(puml, IsClass(_A("C")));
+
+    save_puml(
+        "./" + config.output_directory() + "/" + diagram->name + ".puml", puml);
+}

--- a/tests/test_cases.cc
+++ b/tests/test_cases.cc
@@ -243,6 +243,7 @@ using namespace clanguml::test::matchers;
 #include "t00048/test_case.h"
 #include "t00049/test_case.h"
 #include "t00050/test_case.h"
+#include "t00051/test_case.h"
 
 ///
 /// Sequence diagram tests

--- a/tests/test_cases.yaml
+++ b/tests/test_cases.yaml
@@ -147,6 +147,9 @@ test_cases:
     - name: t00050
       title: Test case for generating notes from comments using jinja templates
       description:
+    - name: t00051
+      title: Test case for anonymous namespace within named namespace
+      description:
   Sequence diagrams:
     - name: t20001
       title: Basic sequence diagram test case


### PR DESCRIPTION
Added a unit test to try and reproduce a suspected issue. I'm running into a problem when executing tests. What am I doing wrong?

```
bramv@WS01:~/src/projects/clang-uml/debug/tests$ ./test_cases
[info] [tid 24231] [generator.h:460] Generating diagram t00002_class.puml
LLVM ERROR: Cannot chdir into "/home/bramv/src/projects/clang-uml/debug/tests"!

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test_cases is a Catch v2.13.8 host application.
Run with -? for options

-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
t00002
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
/home/bramv/src/projects/clang-uml/tests/t00002/test_case.h:19
...............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

/home/bramv/src/projects/clang-uml/tests/t00002/test_case.h:19: FAILED:
  {Unknown expression after the reported line}
due to a fatal error condition:
  SIGABRT - Abort (abnormal termination) signal

===============================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================
test cases: 1 | 1 failed
assertions: 5 | 4 passed | 1 failed

Aborted (core dumped)

```