### PR TITLE
Added unit test to reproduce segfault.

### DIFF
--- a/tests/t00002/t00002.cc
+++ b/tests/t00002/t00002.cc
@@ -15,7 +15,11 @@ public:
 /// \brief This is class B
 class B : public A {
 public:
+    B() { }
     virtual void foo_a() override { }
+
+protected:
+    void foo_b() const { }
 };
 
 /// @brief This is class C - class C has a long comment
@@ -81,6 +85,17 @@ public:
 private:
     /// All the A pointers
     std::vector<A *> as;
+};
+
+class F : public B {
+public:
+    using B::B;
+    using B::foo_b;
+};
+
+struct G : private B {
+    using B::B;
+    using B::foo_b;
 };
 } // namespace t00002
 } // namespace clanguml

--- a/tests/t00003/t00003.cc
+++ b/tests/t00003/t00003.cc
@@ -1,5 +1,6 @@
 #include <functional>
 #include <string>
+#include <thread>
 
 namespace clanguml {
 namespace t00003 {
@@ -50,8 +51,35 @@ private:
 
     int private_member;
     int a_, b_, c_;
+
+    class custom_thread1 : private std::thread {
+    public:
+        template <class Function, class... Args>
+        explicit custom_thread1(Function &&f, Args &&...args)
+            : std::thread::thread(
+                  std::forward<Function>(f), std::forward<Args>(args)...)
+        {
+        }
+    };
+    static custom_thread1 start_thread1();
+
+    class custom_thread2 : private std::thread {
+        using std::thread::thread;
+    };
+    static custom_thread2 start_thread2();
 };
 
 int A::static_int = 1;
+
+A::custom_thread1 A::start_thread1()
+{
+    return custom_thread1{[]() {}};
+}
+
+A::custom_thread2 A::start_thread2()
+{
+    return custom_thread2{[]() {}};
+}
+
 } // namespace t00003
 } // namespace clanguml


### PR DESCRIPTION
The segfault can be reproduced by running t00003.

The segfault is related to the using clause in nested class custom_thread2:

`using std::thread::thread;`

When everything related to custom_thread2 is removed, the segfault does not occur.

class custom_thread1 redefines the variadic ctor, which does not cause the segfault.

The using clauses in t00002 were added to exclude the usage of using clauses as a possible cause for the segfault.