### PR TITLE
Skip dependencies between parent and child packages

### DIFF
--- a/src/common/model/diagram_element.cc
+++ b/src/common/model/diagram_element.cc
@@ -30,6 +30,16 @@ diagram_element::id_t diagram_element::id() const { return id_; }
 
 void diagram_element::set_id(diagram_element::id_t id) { id_ = id; }
 
+std::optional<id_t> diagram_element::parent_element_id() const
+{
+    return parent_element_id_;
+}
+
+void diagram_element::set_parent_element_id(diagram_element::id_t id)
+{
+    parent_element_id_ = id;
+}
+
 std::string diagram_element::alias() const
 {
     assert(id_ >= 0);

--- a/src/common/model/diagram_element.h
+++ b/src/common/model/diagram_element.h
@@ -65,6 +65,20 @@ public:
     void set_id(id_t id);
 
     /**
+     * Get elements parent package id.
+     *
+     * @return Parent package id if element is nested.
+     */
+    std::optional<id_t> parent_element_id() const;
+
+    /**
+     * Set elements parent package id.
+     *
+     * @param id Id of parent package.
+     */
+    void set_parent_element_id(diagram_element::id_t id);
+
+    /**
      * @brief Return elements' diagram alias.
      *
      * @todo This is a PlantUML specific method - it shouldn't be here.
@@ -174,6 +188,7 @@ public:
 
 private:
     id_t id_{0};
+    std::optional<id_t> parent_element_id_{0};
     std::string name_;
     std::vector<relationship> relationships_;
     bool nested_{false};

--- a/src/common/model/diagram_filter.cc
+++ b/src/common/model/diagram_filter.cc
@@ -248,10 +248,6 @@ tvl::value_t namespace_filter::match(const diagram &d, const element &e) const
                     e.full_name(false);
             });
 
-        if (tvl::is_false(result))
-            LOG_DBG("Element {} rejected by namespace_filter 1",
-                e.full_name(false));
-
         return result;
     }
 
@@ -273,10 +269,6 @@ tvl::value_t namespace_filter::match(const diagram &d, const element &e) const
                     e.full_name(false);
             });
 
-        if (tvl::is_false(result))
-            LOG_DBG("Element {} rejected by namespace_filter (package diagram)",
-                e.full_name(false));
-
         return result;
     }
 
@@ -289,9 +281,6 @@ tvl::value_t namespace_filter::match(const diagram &d, const element &e) const
 
             return std::get<common::regex>(nsit.value()) %= e.full_name(false);
         });
-
-    if (tvl::is_false(result))
-        LOG_DBG("Element {} rejected by namespace_filter", e.full_name(false));
 
     return result;
 }

--- a/src/common/model/nested_trait.h
+++ b/src/common/model/nested_trait.h
@@ -94,9 +94,11 @@ public:
 
         auto parent = get_element(path);
 
-        if (parent && dynamic_cast<nested_trait<T, Path> *>(&parent.value()))
+        if (parent && dynamic_cast<nested_trait<T, Path> *>(&parent.value())) {
+            p->set_parent_element_id(parent.value().id());
             return dynamic_cast<nested_trait<T, Path> &>(parent.value())
                 .template add_element<V>(std::move(p));
+        }
 
         LOG_INFO("No parent element found at: {}", path.to_string());
 

--- a/src/package_diagram/generators/plantuml/package_diagram_generator.cc
+++ b/src/package_diagram/generators/plantuml/package_diagram_generator.cc
@@ -62,8 +62,9 @@ void generator::generate_relationships(
 
     // Process it's subpackages relationships
     for (const auto &subpackage : p) {
-        generate_relationships(
-            dynamic_cast<const package &>(*subpackage), ostr);
+        if (model().should_include(dynamic_cast<const package &>(*subpackage)))
+            generate_relationships(
+                dynamic_cast<const package &>(*subpackage), ostr);
     }
 }
 

--- a/src/package_diagram/visitor/translation_unit_visitor.h
+++ b/src/package_diagram/visitor/translation_unit_visitor.h
@@ -214,6 +214,9 @@ private:
     void add_relationships(
         clang::Decl *cls, found_relationships_t &relationships);
 
+    std::vector<common::model::diagram_element::id_t> get_parent_package_ids(
+        common::model::diagram_element::id_t id);
+
     // Reference to the output diagram model
     clanguml::package_diagram::model::diagram &diagram_;
 


### PR DESCRIPTION
Skip dependencies between parent and child packages in package diagrams (Fixes #186)