### PR TITLE
Nix package: add wrapper to fix stdlib includes

### DIFF
--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -14,10 +14,6 @@ stdenv.mkDerivation {
   name = "clang-uml";
   src = ../..;
 
-  # variables for substituteAll
-  unwrapped = llvmPackages.clang-unwrapped;
-  clang = if enableLibcxx then llvmPackages.libcxxClang else llvmPackages.clang;
-
   nativeBuildInputs = [
     cmake
     pkg-config
@@ -31,8 +27,15 @@ stdenv.mkDerivation {
     yaml-cpp
   ];
 
+  clang = if enableLibcxx then llvmPackages.libcxxClang else llvmPackages.clang;
+
   postInstall = ''
+    export unwrapped_clang_uml="$out/bin/clang-uml"
+    
+    # inject clang and unwrapp_clang_uml variables into wrapper
     substituteAll ${./wrapper} $out/bin/clang-uml-wrapped
+    chmod +x $out/bin/clang-uml-wrapped
+
     installShellCompletion --bash $src/packaging/autocomplete/clang-uml
     installShellCompletion --zsh $src/packaging/autocomplete/_clang-uml
   '';

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -4,12 +4,19 @@
   pkg-config,
   installShellFiles,
   libclang,
+  clang,
+  llvmPackages,
   libllvm,
   yaml-cpp,
+  enableLibcxx ? false,
 }:
 stdenv.mkDerivation {
   name = "clang-uml";
   src = ../..;
+
+  # variables for substituteAll
+  unwrapped = llvmPackages.clang-unwrapped;
+  clang = if enableLibcxx then llvmPackages.libcxxClang else llvmPackages.clang;
 
   nativeBuildInputs = [
     cmake
@@ -18,12 +25,14 @@ stdenv.mkDerivation {
   ];
 
   buildInputs = [
+    clang
     libclang
     libllvm
     yaml-cpp
   ];
 
   postInstall = ''
+    substituteAll ${./wrapper} $out/bin/clang-uml-wrapped
     installShellCompletion --bash $src/packaging/autocomplete/clang-uml
     installShellCompletion --zsh $src/packaging/autocomplete/_clang-uml
   '';

--- a/packaging/nix/wrapper
+++ b/packaging/nix/wrapper
@@ -28,4 +28,4 @@ export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}${CPLUS_INCLUDE_PATH:+':'}$(build
                                                                                       $(<@clang@/nix-support/libcxx-cxxflags) \
                                                                                       $(<@clang@/nix-support/libc-cflags)):@clang@/resource-root/include
 
-exec -a "$0" @unwrapped@/bin/$(basename $0) "$@"
+exec @unwrapped_clang_uml@ "$@"

--- a/packaging/nix/wrapper
+++ b/packaging/nix/wrapper
@@ -1,0 +1,31 @@
+#!/bin/sh
+# This file is copied from https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/clang-tools/wrapper
+# The clang-tools wrapper is commonly used together with the clang package on
+# nix, because without the wrapper, clang tools fail to find stdlib includes on
+# nix.
+
+buildcpath() {
+  local path after
+  while (( $# )); do
+    case $1 in
+        -isystem)
+            shift
+            path=$path${path:+':'}$1
+            ;;
+        -idirafter)
+            shift
+            after=$after${after:+':'}$1
+            ;;
+    esac
+    shift
+  done
+  echo $path${after:+':'}$after
+}
+
+export CPATH=${CPATH}${CPATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE} \
+                                               $(<@clang@/nix-support/libc-cflags)):@clang@/resource-root/include
+export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}${CPLUS_INCLUDE_PATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE} \
+                                                                                      $(<@clang@/nix-support/libcxx-cxxflags) \
+                                                                                      $(<@clang@/nix-support/libc-cflags)):@clang@/resource-root/include
+
+exec -a "$0" @unwrapped@/bin/$(basename $0) "$@"


### PR DESCRIPTION
Problem: Clang-uml doesnt find standard library includes on nixos.

Background: Since nixos is a bit of a special snowflake, compilers dont really work without some additional configuration. Compilers shipped by nixos are therefore wrapped by some small scripts. These wrappers make the compilation and linking steps of compilers compatible with the strict dependency management and versioning of nix. Many clang tools and libclang are not integrated in these wrappers yet, because they are not directly the compiler. This can lead to problems where clangtools/libclang can not find the c/cpp standard libraries.

Solution: Apply the same wrapper that nixos/nixpkgs uses for the clang-tools package. Using the `clang-uml-wrapped` exectuable, the stdlib import errors are resolved.

I think this wrapper is always necessary when using stdlibs from nixos, but perhaps @hatch01 can comment if the existing unwrapped `clang-uml` also works on some nixos installations. Anyways, in this PR i preserve both exectuables for compatibility. 