### PR TITLE
fix segfault in name for unnamed undeclared types

### DIFF
--- a/src/common/clang_utils.cc
+++ b/src/common/clang_utils.cc
@@ -150,7 +150,13 @@ std::string to_string(const clang::QualType &type, const clang::ASTContext &ctx,
         result = "(anonymous)";
     else if (util::contains(result, "unnamed struct") ||
         util::contains(result, "unnamed union")) {
-        result = common::get_tag_name(*type->getAsTagDecl());
+        auto declarationTag = type->getAsTagDecl();
+        if (declarationTag == NULL) {
+            result = "(unnamed undeclared)";
+        }
+        else {
+            result = common::get_tag_name(*declarationTag);
+        }
     }
     else if (util::contains(result, "anonymous struct") ||
         util::contains(result, "anonymous union")) {


### PR DESCRIPTION
type->getAsTagDecl() may return null resulting in a segfault. E.g. in the following example:

```
struct Foo {
  struct {
    uint64_t len;
    uint64_t flags;
  } __attribute__((packed)) bars[BARS]; <-- the type of this bars
  ...
};
```

I found this segfault while working on this code https://github.com/vmuxIO/vmuxIO/commit/d1d44aa84158a6bc2955e62f597b6794b66f221f (`just uml`). This patch solves that segfault. 

I have no prior experience with clang, but i hope my solution is still valid. 