### PR TITLE
packaging: add nixpkgs avalability and make wrapped script the default

### DIFF
--- a/docs/common_options.md
+++ b/docs/common_options.md
@@ -226,11 +226,10 @@ set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTOR
 ```
 
 ### Nix wrapper
-On NixOS or when using `nix`, `clang-uml` provides a wrapper script called
-`clang-uml-wrapped`, which builds and exports `CPATH` and `CPLUS_INCLUDE_PATH`
+On NixOS or when using `nix`, `clang-uml` uses a wrapper script,
+which builds and exports `CPATH` and `CPLUS_INCLUDE_PATH`
 environment variables before running `clang-uml`, which contain valid
 system header Clang paths for the current Nix environment.
 
-The `clang-uml-wrapped` script can be called the same way as `clang-uml` and
-should resolve the system include paths without the need for any of the above
-solutions.
+If you want to use an unwrapped version, the `clang-uml-unwrapped` binary
+can be called the same way as `clang-uml`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -56,7 +56,15 @@ conda install -c bkryza/label/clang-uml clang-uml
 
 #### Nix
 
+You can use the version packaged in nixpkgs like this:
 ```bash
+nix-shell -p clang-uml
+```
+
+Or you can build it by yourself
+
+```bash
+# To build it by yourself
 git clone https://github.com/bkryza/clang-uml
 
 # To build using nix flakes

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -57,6 +57,7 @@ conda install -c bkryza/label/clang-uml clang-uml
 #### Nix
 
 You can use the version packaged in nixpkgs like this:
+Currently clang-uml version 0.5.1 is available in nixos-unstable and nixos-24.05
 ```bash
 nix-shell -p clang-uml
 ```

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -30,11 +30,13 @@ stdenv.mkDerivation {
   clang = if enableLibcxx then llvmPackages.libcxxClang else llvmPackages.clang;
 
   postInstall = ''
-    export unwrapped_clang_uml="$out/bin/clang-uml"
-    
-    # inject clang and unwrap_clang_uml variables into wrapper
-    substituteAll ${./wrapper} $out/bin/clang-uml-wrapped
-    chmod +x $out/bin/clang-uml-wrapped
+    cp $out/bin/clang-uml $out/bin/clang-uml-unwrapped
+    rm $out/bin/clang-uml
+    export unwrapped_clang_uml="$out/bin/clang-uml-unwrapped"
+
+    # inject clang and unwrapp_clang_uml variables into wrapper
+    substituteAll ${./wrapper} $out/bin/clang-uml
+    chmod +x $out/bin/clang-uml
 
     installShellCompletion --bash $src/packaging/autocomplete/clang-uml
     installShellCompletion --zsh $src/packaging/autocomplete/_clang-uml

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -38,7 +38,8 @@ stdenv.mkDerivation {
     substituteAll ${./wrapper} $out/bin/clang-uml
     chmod +x $out/bin/clang-uml
 
-    installShellCompletion --bash $src/packaging/autocomplete/clang-uml
-    installShellCompletion --zsh $src/packaging/autocomplete/_clang-uml
+    installShellCompletion --cmd clang-uml \
+      --bash $src/packaging/autocomplete/clang-uml \
+      --zsh $src/packaging/autocomplete/_clang-uml
   '';
 }


### PR DESCRIPTION
Just a small doc modification to indicate that now clang-UML is available in nixpkgs, so users don't really need to build it themselves unless they want a specific version directly from a git branch.