### PR TITLE
Added missing header file for the t00092 test for gcc 12 compatibility

### DIFF
--- a/tests/t00092/t00092.cc
+++ b/tests/t00092/t00092.cc
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <map>
 
 namespace clanguml::t00092 {


### PR DESCRIPTION
Added missing header file for the t00092 test for gcc 12 compatibility