### PR TITLE
Fix link yaml-cpp in linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,9 @@ endif(MSVC)
 if(APPLE)
     set(YAML_CPP_LIBRARIES yaml-cpp::yaml-cpp)
 endif(APPLE)
+if(LINUX)
+    set(YAML_CPP_LIBRARIES yaml-cpp)
+endif(LINUX)
 message(STATUS "Found yaml-cpp at: ${YAML_CPP_INCLUDE_DIR}, library: ${YAML_CPP_LIBRARIES}")
 
 #


### PR DESCRIPTION
# Fix link yaml-cpp in linux

## Modern way

The modern approach in cmake for connecting a library is to find and use target_link_libraries. This approach will work in windows and macos. Unfortunately I have no way to test it, so I decided not to change the approach.
```cmake
find_package(yaml-cpp REQUIRED)

add_executable(clang-uml)
# this link library and include necessary headers
target_link_libraries(clang-uml PUBLIC yaml-cpp)
```

## Example

it is possible to check the work of yaml-cpp library search for example in such a minimal container:
```Dockerfile
FROM debian:12.9

ARG nproc=4

ENV PATH=/opt/deps/bin:$PATH
ENV CPATH=/opt/deps/include:$CPATH
ENV LD_LIBRARY_PATH=/opt/deps/lib64:/opt/deps/lib:$LD_LIBRARY_PATH
ENV PKG_CONFIG_PATH=/opt/deps/lib64/pkgconfig:/opt/deps/lib/pkgconfig:$PKG_CONFIG_PATH

WORKDIR /opt

RUN apt update && \
    apt install -y --no-install-suggests --no-install-recommends \
        git gnupg ca-certificates curl pkg-config openssh-client \
        g++ gcc cmake make ninja-build python3 \
        unzip && \
    apt clean && \
    rm -rf /var/lib/apt/lists/*

ARG yaml_version=0.7.0
ARG yaml_build_shared=on
RUN git clone https://github.com/jbeder/yaml-cpp.git \
        -b yaml-cpp-$yaml_version --depth 1 --recursive && \
    mkdir yaml-cpp/build && cd yaml-cpp/build && \
    cmake .. \
        -D YAML_BUILD_SHARED_LIBS=$yaml_build_shared \
        -D CMAKE_INSTALL_PREFIX="/opt/deps" \
        -D CMAKE_BUILD_TYPE="release" && \
    cmake --build . -- -j$nproc && \
    cmake --install . && \
    rm -rf /opt/yaml-cpp

ARG clang_version=17.0.6
ARG clang_build_shared=on
RUN curl -sfLo sources.zip --create-dirs \
        https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-$clang_version.zip && \
    unzip sources.zip > /dev/null && rm -rf sources.zip && \
    mv -f llvm-project-* llvm-project && \
    cd llvm-project && mkdir build && cd build && \
    cmake -S ../llvm \
        -D LLVM_TARGETS_TO_BUILD="X86" \
        -D LLVM_ENABLE_PROJECTS="clang" \
        -D LLVM_ENABLE_RTTI=on \
        -D LLVM_BUILD_LLVM_DYLIB=$clang_build_shared \
        -D CLANG_DEFAULT_CXX_STDLIB="libstdc++" \
        -D CMAKE_INSTALL_PREFIX="/opt/deps" \
        -D CMAKE_BUILD_TYPE="release" && \
    cmake --build . -- -j$nproc && \
    cmake --install . && \
    rm -rf /opt/llvm-project
```