### PR TITLE
Add fallback to static llvm build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,9 @@ endif(MSVC)
 if(APPLE)
     set(YAML_CPP_LIBRARIES yaml-cpp::yaml-cpp)
 endif(APPLE)
+if(LINUX)
+    set(YAML_CPP_LIBRARIES yaml-cpp)
+endif(LINUX)
 message(STATUS "Found yaml-cpp at: ${YAML_CPP_INCLUDE_DIR}, library: ${YAML_CPP_LIBRARIES}")
 
 #

--- a/cmake/LLVMSetup.cmake
+++ b/cmake/LLVMSetup.cmake
@@ -43,6 +43,10 @@ message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake from: ${LLVM_CMAKE_DIR}")
 message(STATUS "LLVM library dir: ${LLVM_LIBRARY_DIR}")
 
+if(NOT LLVM IN_LIST LLVM_AVAILABLE_LIBS)
+    set(LINK_LLVM_SHARED NO)
+endif()
+
 if(MSVC)
     # LLVM_BUILD_LLVM_DYLIB is not available on Windows
     set(LINK_LLVM_SHARED NO)


### PR DESCRIPTION
# Add fallback to static llvm build

Added the ability to build as a project both with and without the `LLVM.so` dynamic library. It is no longer necessary to specify a separate `LINK_LLVM_SHARED` flag for this purpose during the build process

## Assumption
Maybe MSVC check is no longer needed, but I can't check it now

```cmake
if(NOT LLVM IN_LIST LLVM_AVAILABLE_LIBS)
    set(LINK_LLVM_SHARED NO)
endif()

# Maybe this check is no longer needed, but I can't check it now
if(MSVC)
    # LLVM_BUILD_LLVM_DYLIB is not available on Windows
    set(LINK_LLVM_SHARED NO)
endif(MSVC)
```

## Example

```Dockerfile
FROM debian:12.9

ARG nproc=4

ENV PATH=/opt/deps/bin:$PATH
ENV CPATH=/opt/deps/include:$CPATH
ENV LD_LIBRARY_PATH=/opt/deps/lib64:/opt/deps/lib:$LD_LIBRARY_PATH
ENV PKG_CONFIG_PATH=/opt/deps/lib64/pkgconfig:/opt/deps/lib/pkgconfig:$PKG_CONFIG_PATH

WORKDIR /opt

RUN apt update && \
    apt install -y --no-install-suggests --no-install-recommends \
        git gnupg ca-certificates curl pkg-config openssh-client \
        g++ gcc cmake make ninja-build python3 \
        unzip && \
    apt clean && \
    rm -rf /var/lib/apt/lists/*

ARG yaml_version=0.7.0
RUN git clone https://github.com/jbeder/yaml-cpp.git \
        -b yaml-cpp-$yaml_version --depth 1 --recursive && \
    mkdir yaml-cpp/build && cd yaml-cpp/build && \
    cmake .. \
        -D YAML_BUILD_SHARED_LIBS=on \
        -D CMAKE_INSTALL_PREFIX="/opt/deps" \
        -D CMAKE_BUILD_TYPE="release" && \
    cmake --build . -- -j$nproc && \
    cmake --install . && \
    rm -rf /opt/yaml-cpp

# this build llvm without LLVM.so
# you can change this behavior using LLVM_BUILD_LLVM_DYLIB flag
ARG clang_version=17.0.6
RUN curl -sfLo sources.zip --create-dirs \
        https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-$clang_version.zip && \
    unzip sources.zip > /dev/null && rm -rf sources.zip && \
    mv -f llvm-project-* llvm-project && \
    cd llvm-project && mkdir build && cd build && \
    cmake -S ../llvm \
        -D LLVM_TARGETS_TO_BUILD="X86" \
        -D LLVM_ENABLE_PROJECTS="clang" \
        -D LLVM_ENABLE_RTTI=on \
        -D LLVM_BUILD_LLVM_DYLIB=off \
        -D CLANG_DEFAULT_CXX_STDLIB="libstdc++" \
        -D CMAKE_INSTALL_PREFIX="/opt/deps" \
        -D CMAKE_BUILD_TYPE="release" && \
    cmake --build . -- -j$nproc && \
    cmake --install . && \
    rm -rf /opt/llvm-project
```

### Depends on #411