### PR TITLE
AI slop - solved building issue for fedora 43 on my system. Just  FYI

### DIFF
--- a/tests/test_clang_util.cc
+++ b/tests/test_clang_util.cc
@@ -144,14 +144,16 @@ TEST_CASE("Test diagnostic_consumer")
     auto fs = llvm::vfs::getRealFileSystem();
     FileSystemOptions file_opts;
     FileManager file_mgr(file_opts, fs);
+    DiagnosticOptions diag_opts;
     auto diagnostic_engine = DiagnosticsEngine(
         llvm::IntrusiveRefCntPtr<DiagnosticIDs>(new DiagnosticIDs()),
-        new DiagnosticOptions());
+        diag_opts);
     SourceManager source_mgr(diagnostic_engine, file_mgr);
 
+    DiagnosticOptions diag_opts2;
     DiagnosticsEngine diag_engine(
         llvm::IntrusiveRefCntPtr<DiagnosticIDs>(new DiagnosticIDs()),
-        new DiagnosticOptions());
+        diag_opts2);
 
     diag_engine.setClient(&consumer, false);
     auto id_note = diag_engine.getCustomDiagID(


### PR DESCRIPTION
```
 ➜ make release
cmake -S . -B release \
        -G"Unix Makefiles" \
        -DGIT_VERSION=0.6.2-28-gd600c52 \
        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
        -DCMAKE_BUILD_TYPE=Release \
        -DCMAKE_CXX_FLAGS="" \
        -DCMAKE_EXE_LINKER_FLAGS="" \
        -DLLVM_VERSION= \
        -DLLVM_CONFIG_PATH= \
        -DLINK_LLVM_SHARED=ON \
        -DCMAKE_PREFIX= \
        -DCMAKE_OSX_SYSROOT= \
        -DADDRESS_SANITIZER=OFF \
        -DENABLE_CUDA_TEST_CASES=OFF \
        -DENABLE_CXX_MODULES_TEST_CASES=OFF \
        -DENABLE_OBJECTIVE_C_TEST_CASES=OFF \
        -DENABLE_BENCHMARKS=OFF \
        -DFETCH_LIBOBJC2=OFF \
        -DCLANG_UML_ENABLE_BACKTRACE=OFF
-- clang-uml version: 0.6.2-28-gd600c52
-- Checking for LLVM and Clang...
-- Found LLVM 21.1.8
-- Using LLVMConfig.cmake from: /usr/lib64/cmake/llvm
-- LLVM library dir: /usr/lib64
-- Found LibTooling libraries: clang-cpp;LLVM
-- Checking for yaml-cpp...
-- Found yaml-cpp at: /usr/include, library: yaml-cpp
-- Disabling backward-cpp
-- Disabling Objective-C test cases
-- Disabling C++ modules test cases
-- Disabling CUDA test cases
-- Enabling C++20 test cases
-- Configuring done (0.1s)
-- Generating done (0.1s)
-- Build files have been written to: /home/krzysiek2/Dokumenty/clang-uml/release
cmake --build release -j24
gmake[1]: Entering directory '/home/krzysiek2/Dokumenty/clang-uml/release'
[  0%] Built target pugixml
[  1%] Building CXX object src/CMakeFiles/clang-umllib.dir/version/version.cc.o
[ 29%] Built target clang-umllib
[ 30%] Linking CXX executable test_model
[ 31%] Linking CXX executable test_types
[ 31%] Linking CXX executable test_config
[ 31%] Linking CXX executable test_levenshtein
[ 32%] Linking CXX executable test_query_driver_output_extractor
[ 32%] Linking CXX executable test_cli_handler
[ 32%] Linking CXX executable test_nested_trait
[ 32%] Linking CXX executable test_decorator_parser
[ 32%] Linking CXX executable test_thread_pool_executor
[ 33%] Linking CXX executable test_util
[ 33%] Linking CXX executable test_filters
[ 33%] Linking CXX executable clang-uml
[ 34%] Linking CXX executable test_filters_advanced
[ 34%] Linking CXX executable test_compilation_database
[ 34%] Linking CXX executable test_progress_indicator
[ 35%] Linking CXX executable test_clang_util
[ 35%] Linking CXX executable test_cases
[ 35%] Built target test_thread_pool_executor
[ 35%] Built target test_util
[ 36%] Built target test_compilation_database
[ 36%] Built target test_filters_advanced
[ 36%] Built target test_model
[ 36%] Built target test_cli_handler
[ 37%] Built target test_filters
[ 38%] Built target test_types
[ 39%] Built target test_levenshtein
[ 39%] Built target test_progress_indicator
[ 39%] Built target test_nested_trait
[ 39%] Built target test_clang_util
[ 39%] Built target clang-uml
[ 39%] Built target test_decorator_parser
[ 39%] Built target test_config
[ 39%] Built target test_query_driver_output_extractor
[100%] Built target test_cases
gmake[1]: Leaving directory '/home/krzysiek2/Dokumenty/clang-uml/release'

```