### PR TITLE
Fixed tests building with LLVM 21 (#447)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+  * Fixed tests building with LLVM 21 (#447, Thanks @krzysiek358)
+
 ### 0.6.2
   * Added support for LLVM 21 (#419)
   * Added generate_method_argument_names options for sequence diagrams (#404)

--- a/tests/test_clang_util.cc
+++ b/tests/test_clang_util.cc
@@ -144,14 +144,25 @@ TEST_CASE("Test diagnostic_consumer")
     auto fs = llvm::vfs::getRealFileSystem();
     FileSystemOptions file_opts;
     FileManager file_mgr(file_opts, fs);
+    DiagnosticOptions diag_opts;
     auto diagnostic_engine = DiagnosticsEngine(
         llvm::IntrusiveRefCntPtr<DiagnosticIDs>(new DiagnosticIDs()),
-        new DiagnosticOptions());
+#if LLVM_VERSION_MAJOR > 20
+        diag_opts
+#else
+        new DiagnosticOptions()
+#endif
+    );
     SourceManager source_mgr(diagnostic_engine, file_mgr);
 
     DiagnosticsEngine diag_engine(
         llvm::IntrusiveRefCntPtr<DiagnosticIDs>(new DiagnosticIDs()),
-        new DiagnosticOptions());
+#if LLVM_VERSION_MAJOR > 20
+        diag_opts
+#else
+        new DiagnosticOptions()
+#endif
+    );
 
     diag_engine.setClient(&consumer, false);
     auto id_note = diag_engine.getCustomDiagID(


### PR DESCRIPTION
Fixes build test_clang_utils on LLVM 21, originally reported by @krzysiek358 here: #447 