### PR TITLE
Fix building with Clang 21

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
                                    -Wno-invalid-constexpr
                                    -Wno-deprecated-anon-enum-enum-conversion)
     endif()
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 21)
+        set(CUSTOM_COMPILE_OPTIONS ${CUSTOM_COMPILE_OPTIONS}
+            -Wno-preferred-type-bitfield-enum-conversion
+            -Wno-unnecessary-virtual-specifier)
+    endif()
 endif()
 
 link_directories(${LLVM_LIBRARY_DIR})


### PR DESCRIPTION
This silences warnings like

/usr/local/llvm19/include/clang/Basic/LangOptions.def:349:1: error: assigning value of preferred signed enum type 'FPEvalMethodKind' to unsigned bit-field 'FPEvalMethod'; negative enumerators of enum 'FPEvalMethodKind' will be converted to positive values [-Werror,-Wpreferred-type-bitfield-enum-conversion]

and

/usr/local/llvm19/include/clang/AST/DeclFriend.h:55:16: error: virtual method 'anchor' is inside a 'final' class and can never be overridden [-Werror,-Wunnecessary-virtual-specifier]